### PR TITLE
Adding support for the most recent version of otto.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/tiborvass/go-jsx
+
+go 1.13
+
+require (
+	github.com/robertkrimen/otto v0.0.0-20191219234010-c382bd3c16ff
+	gopkg.in/sourcemap.v1 v1.0.5 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/robertkrimen/otto v0.0.0-20191219234010-c382bd3c16ff h1:+6NUiITWwE5q1KO6SAfUX918c+Tab0+tGAM/mtdlUyA=
+github.com/robertkrimen/otto v0.0.0-20191219234010-c382bd3c16ff/go.mod h1:xvqspoSXJTIpemEonrMDFq6XzwHYYgToXWj5eRX1OtY=
+gopkg.in/sourcemap.v1 v1.0.5 h1:inv58fC9f9J3TK2Y2R1NPntXEn3/wjWHkonhIUODNTI=
+gopkg.in/sourcemap.v1 v1.0.5/go.mod h1:2RlvNNSMglmRrcvhfuzp4hQHwOtjxlbjX7UPY/GXb78=

--- a/jsx.go
+++ b/jsx.go
@@ -36,6 +36,6 @@ func eval(fset *file.FileSet, program *ast.Program, err error) (string, error) {
 	}
 
 	r := NewReact(fset, errList, program.File)
-	Walk(r, program)
+	ast.Walk(r, program)
 	return r.String(), nil
 }

--- a/react.go
+++ b/react.go
@@ -33,11 +33,11 @@ func (v *React) String() string {
 // TODO: refactor this and expose only something like the current `v.str()` to spare
 // others from reimplementing the whole visitor when all they need is to provide a
 // string given an *ElementNode.
-func (v *React) Visit(node ast.Node) Visitor {
+func (v *React) Enter(node ast.Node) ast.Visitor {
 	switch n := node.(type) {
 	case *ast.Program:
 		for _, stmt := range n.Body {
-			Walk(v, stmt)
+			ast.Walk(v, stmt)
 		}
 		src := v.file.Source()
 		// print the rest
@@ -188,4 +188,8 @@ func (r *React) ensureDisplayName(name string, init ast.Expression) {
 	r.result.WriteString(s)
 	r.last += file.Idx(len(s))
 	r.result.WriteString(`displayName: "` + name + `",`)
+}
+
+func (v *React) Exit(node ast.Node) {
+
 }

--- a/react.go
+++ b/react.go
@@ -49,7 +49,7 @@ func (v *React) Enter(node ast.Node) ast.Visitor {
 		for _, err := range v.errList {
 			pos := v.fset.Position(n.From)
 			// This is the hack to "identify" JSX code within Javascript.
-			if pos.Column == err.Position.Column && pos.Line == err.Position.Line && strings.Contains(err.Message, "Unexpected token <") {
+			if pos.Column == err.Position.Column-1 && pos.Line == err.Position.Line && strings.Contains(err.Message, "Unexpected token <") {
 				src := v.file.Source()
 				// Print everything from last time up until `<`, not included.
 				v.result.WriteString(src[v.last : n.From-1])


### PR DESCRIPTION
This Branch compiles now with Go 1.13.
It also adds support for the most recent API of Otto.

Fixes #1 